### PR TITLE
[WEB-2279] Add updateSubscription() method to ecom

### DIFF
--- a/src/Ecom.js
+++ b/src/Ecom.js
@@ -46,4 +46,25 @@ export default class Ecom extends Service {
       null
     )
   }
+
+  /**
+   * Update the payment method and number of billing cycles of a subscription identified by a given subscription ID.
+   * Requires a valid access token.
+   *
+   * @param {Object} param Options
+   * @param {String} param.subscriptionId ID of the subscription to update
+   * @param {String} param.paymentToken
+   * @param {Number} param.numberOfBillingCycle
+   * @return {Promise}
+   */
+  updateSubscription ({ subscriptionId, paymentToken, numberOfBillingCycle }) {
+    return this.fetch(
+      this.bearerTokenAuthHeader(),
+      this.userId === 0 ? '/api/v1/me/subscriptions/' + subscriptionId : '/api/v1/users/' + this.userId + '/subscriptions/' + subscriptionId,
+      this.toBody({
+        'number_of_billing_cycle': numberOfBillingCycle, 'payment_method_token': paymentToken
+      }),
+      'PUT'
+    )
+  }
 }

--- a/test/integration/EcomTest.js
+++ b/test/integration/EcomTest.js
@@ -63,5 +63,37 @@ describe('Ecom Tests', function () {
         )
       }
     )
+
+    it(`confirms URI used in 'updateSubscription()' method with no user ID, by returning a non-404 HTTP response`,
+      function () {
+        swsClient.userId = 0
+        return swsClient.ecom.updateSubscription({
+          subscriptionId: 'test-id',
+          paymentToken: 'abc',
+          numberOfBillingCycle: 2
+        }).then(
+          () => Promise.reject(new Error('Expected non-2xx HTTP response code')),
+          err => {
+            expect(err.httpStatus).not.to.equal(404)
+          }
+        )
+      }
+    )
+
+    it(`confirms URI used in 'updateSubscription()' method with a user ID, by returning a non-404 HTTP response`,
+      function () {
+        swsClient.userId = 123
+        return swsClient.ecom.updateSubscription({
+          subscriptionId: 'test-id',
+          paymentToken: 'abc',
+          numberOfBillingCycle: 2
+        }).then(
+          () => Promise.reject(new Error('Expected non-2xx HTTP response code')),
+          err => {
+            expect(err.httpStatus).not.to.equal(404)
+          }
+        )
+      }
+    )
   })
 })


### PR DESCRIPTION
- Add updateSubscription() method to ecom
- Basic integration tests

For /me/subscriptions/{subscription_id} and /users/{user_id}/subscriptions/{subscription_id} (PUT).