### PR TITLE
[WEB-2301] Get invoice endpoint

### DIFF
--- a/src/Ecom.js
+++ b/src/Ecom.js
@@ -174,7 +174,7 @@ export default class Ecom extends Service {
    * @param orderId ID of the order for which an invoice will be returned.
    * @return {Promise}
    */
-  getInvoicePdf (orderId) {
+  getInvoice (orderId) {
     return this.fetch(
       this.bearerTokenAuthHeader(),
       this.userId === 0 ? '/api/v1/me/orders/' + orderId + '/invoice' : '/api/v1/users/' + this.userId + '/orders/' +

--- a/src/Ecom.js
+++ b/src/Ecom.js
@@ -34,12 +34,12 @@ export default class Ecom extends Service {
   }
 
   /**
-  * Return orders owned by a user.
-  * Requires a valid access token.
-  *
-  * @param orderStatus
-  * @returns {Promise}
-  */
+   * Return orders owned by a user.
+   * Requires a valid access token.
+   *
+   * @param orderStatus
+   * @returns {Promise}
+   */
   getOrders ({ orderStatus } = {}) {
     return this.fetch(
       this.bearerTokenAuthHeader(),
@@ -88,11 +88,11 @@ export default class Ecom extends Service {
   }
 
   /**
-  * Return payment methods added by a logged-in user.
-  * Requires a valid access token.
-  *
-  * @returns {Promise}
-  */
+   * Return payment methods added by a logged-in user.
+   * Requires a valid access token.
+   *
+   * @returns {Promise}
+   */
   getPaymentMethods () {
     return this.fetch(
       this.bearerTokenAuthHeader(),
@@ -134,7 +134,7 @@ export default class Ecom extends Service {
     return this.fetch(
       this.bearerTokenAuthHeader(),
       this.userId === 0 ? '/api/v1/me/paymentmethods/' + paymentToken : '/api/v1/users/' + this.userId +
-      '/paymentmethods/' + paymentToken,
+        '/paymentmethods/' + paymentToken,
       null,
       'DELETE'
     )
@@ -163,6 +163,23 @@ export default class Ecom extends Service {
         billing_address_id: billingAddressId
       }),
       'PUT'
+    )
+  }
+
+  /**
+   * Retrieve an invoice PDF for the given order.
+   * The logged-in user must be the order's owner.
+   * Requires a valid access token.
+   *
+   * @param orderId ID of the order for which an invoice will be returned.
+   * @return {Promise}
+   */
+  getInvoicePdf (orderId) {
+    return this.fetch(
+      this.bearerTokenAuthHeader(),
+      this.userId === 0 ? '/api/v1/me/orders/pdf/' + orderId : '/api/v1/users/' + this.userId + '/orders/pdf/' +
+        orderId,
+      null
     )
   }
 }

--- a/src/Ecom.js
+++ b/src/Ecom.js
@@ -179,7 +179,14 @@ export default class Ecom extends Service {
       this.bearerTokenAuthHeader(),
       this.userId === 0 ? '/api/v1/me/orders/' + orderId + '/invoice' : '/api/v1/users/' + this.userId + '/orders/' +
         orderId + '/invoice',
-      null
+      null,
+      'GET',
+      null,
+      'blob',
+      {
+        'Accept': 'application/pdf',
+        'Content-Type': 'json'
+      }
     )
   }
 }

--- a/src/Ecom.js
+++ b/src/Ecom.js
@@ -177,8 +177,8 @@ export default class Ecom extends Service {
   getInvoicePdf (orderId) {
     return this.fetch(
       this.bearerTokenAuthHeader(),
-      this.userId === 0 ? '/api/v1/me/orders/pdf/' + orderId : '/api/v1/users/' + this.userId + '/orders/pdf/' +
-        orderId,
+      this.userId === 0 ? '/api/v1/me/orders/' + orderId + '/invoice' : '/api/v1/users/' + this.userId + '/orders/' +
+        orderId + '/invoice',
       null
     )
   }

--- a/src/Service.js
+++ b/src/Service.js
@@ -94,16 +94,20 @@ export default class Service {
    * @param  {String} endpoint API endpoint
    * @param  {Object} body Object to send in the body
    * @param  {String} method HTTP Method GET, POST, PUT or DELETE (defaults to GET)
-   * @param  {Number} timeout Request timout (ms)
+   * @param  {Number} timeout Request timeout (ms)
+   * @param  {String} responseType Response type for the request (e.g. json)
+   * @param  {Object} headers headers Custom headers (defaults to Accept/Content-Type json)
    * @return {Promise}
    */
-  fetch (auth, endpoint, body, method = 'GET', timeout = null) {
+  fetch (auth, endpoint, body, method = 'GET', timeout = null, responseType = 'json', headers = null) {
     this._lastRequest = buildRequest(
       auth,
       (this.serviceUri.indexOf('://') === -1 ? 'https://' : '') + this.serviceUri + endpoint,
       body,
       method,
-      timeout === null ? this._sws.timeout : timeout
+      timeout === null ? this._sws.timeout : timeout,
+      responseType,
+      headers
     )
     return this.fetchRequest(this._lastRequest)
   }
@@ -296,15 +300,17 @@ function handleFetchError (err) {
  * @param  {Object} body Object to send in the body
  * @param  {String} method HTTP Method GET, POST, PUT or DELETE (defaults to GET)
  * @param  {Number} timeout Request timout (ms)
+ * @param  {String} responseType Response type for the request (e.g. json)
+ * @param  {Object} headers Custom headers (defaults to Accept/Content-Type json)
  * @return {Object}
  */
-function buildRequest (auth, endpoint, body, method, timeout) {
+function buildRequest (auth, endpoint, body, method, timeout, responseType, headers = null) {
   let request = {
     timeout: timeout,
     url: endpoint,
     method: method,
-    responseType: 'json',
-    headers: {
+    responseType: responseType,
+    headers: headers || {
       'Accept': 'application/json',
       'Content-Type': 'application/json'
     }

--- a/test/integration/EcomTest.js
+++ b/test/integration/EcomTest.js
@@ -225,5 +225,29 @@ describe('Ecom Tests', function () {
         )
       }
     )
+
+    it(`confirms URI used in 'getInvoicePdf()' method without a user ID by returning a non-404 HTTP response`,
+      function () {
+        swsClient.userId = 0
+        return swsClient.ecom.getInvoicePdf(123).then(
+          () => Promise.reject(new Error('Expected non-2xx HTTP response code')),
+          err => {
+            expect(err.httpStatus).not.to.equal(404)
+          }
+        )
+      }
+    )
+
+    it(`confirms URI used in 'getInvoicePdf()' method with a user ID by returning a non-404 HTTP response`,
+      function () {
+        swsClient.userId = 123
+        return swsClient.ecom.getInvoicePdf(123).then(
+          () => Promise.reject(new Error('Expected non-2xx HTTP response code')),
+          err => {
+            expect(err.httpStatus).not.to.equal(404)
+          }
+        )
+      }
+    )
   })
 })

--- a/test/integration/EcomTest.js
+++ b/test/integration/EcomTest.js
@@ -229,7 +229,7 @@ describe('Ecom Tests', function () {
     it(`confirms URI used in 'getInvoicePdf()' method without a user ID by returning a non-404 HTTP response`,
       function () {
         swsClient.userId = 0
-        return swsClient.ecom.getInvoicePdf(123).then(
+        return swsClient.ecom.getInvoice(123).then(
           () => Promise.reject(new Error('Expected non-2xx HTTP response code')),
           err => {
             expect(err.httpStatus).not.to.equal(404)
@@ -241,7 +241,7 @@ describe('Ecom Tests', function () {
     it(`confirms URI used in 'getInvoicePdf()' method with a user ID by returning a non-404 HTTP response`,
       function () {
         swsClient.userId = 123
-        return swsClient.ecom.getInvoicePdf(123).then(
+        return swsClient.ecom.getInvoice(123).then(
           () => Promise.reject(new Error('Expected non-2xx HTTP response code')),
           err => {
             expect(err.httpStatus).not.to.equal(404)

--- a/test/spec/ServiceTest.js
+++ b/test/spec/ServiceTest.js
@@ -14,6 +14,7 @@ import { expect } from 'chai'
 
 const appId = 'myClientAppId'
 const getLicensesUri = '/api/v1/me/licenses'
+const getInvoiceUri = '/api/v1/me/orders/123/invoice'
 const customHandlerResponse = 'This value is returned by our custom handler'
 
 describe('Service', function () {
@@ -39,6 +40,43 @@ describe('Service', function () {
     )
   })
 
+  it('tests that the response type and Accept header are blob/pdf for the getInvoice() method',
+    function () {
+      nock(/serato/).get(getInvoiceUri, '').reply(200, 'fake-binary-data')
+
+      let sws = new Sws({ appId: appId })
+
+      return sws.ecom.getInvoice(123).then(
+        () => {
+          const request = sws.ecom.lastRequest
+          expect(request.responseType).to.equal('blob')
+          expect(request.headers['Accept']).to.equal('application/pdf')
+        }
+      )
+    }
+  )
+
+  it('tests that the response type and Accept header are defaulted to json for other endpoints',
+    function () {
+      let body = {
+        'some': 'body content',
+        'more': ['body', 'content']
+      }
+
+      nock(/serato/).get(getLicensesUri, '').reply(200, body)
+
+      let sws = new Sws({ appId: appId })
+
+      return sws.license.getLicenses().then(
+        () => {
+          const request = sws.license.lastRequest
+          expect(request.responseType).to.equal('json')
+          expect(request.headers['Accept']).to.equal('application/json')
+        }
+      )
+    }
+  )
+
   /**
    * Test the custom error handlers for errors that include a specific error code.
    * (FWIW, these are all HTTP 4xx status errors that are explicity thrown by the web applications)
@@ -52,11 +90,11 @@ describe('Service', function () {
    * One the sets a custom error handler and asserts that it is used.
    */
 
-  // Define the custom error handler. The err handler receives the error object returned
-  // from the HTTP request.
+    // Define the custom error handler. The err handler receives the error object returned
+    // from the HTTP request.
   let customErrorCodeHandler = (err) => {
-    return `${customHandlerResponse} ${err.response.status} - ${err.response.data.code}`
-  }
+      return `${customHandlerResponse} ${err.response.status} - ${err.response.data.code}`
+    }
 
   const errorsWithCodesTests = [
     // Access token is invalid (eg. bad signature)
@@ -166,11 +204,11 @@ describe('Service', function () {
    * One the sets a custom error handler and asserts that it is used.
    */
 
-  // Define the custom error handler. The err handler receives the error object returned
-  // from the HTTP request.
+    // Define the custom error handler. The err handler receives the error object returned
+    // from the HTTP request.
   const customErrorHandler = (err) => {
-    return `${customHandlerResponse} ${err.response.status}`
-  }
+      return `${customHandlerResponse} ${err.response.status}`
+    }
 
   const errorsWithoutCodesTests = [
     // Unhandled application error


### PR DESCRIPTION
- getInvoice() method
- Add responseType and headers optional parameters to fetch() and buildRequest() (thus making them inelegant? We're essentially now passing in all the request attributes as separate parameters)
- Basic tests