### PR TITLE
[TDO-108] Add option to provide custom request adapter (for use with k6)

### DIFF
--- a/src/Service.js
+++ b/src/Service.js
@@ -14,6 +14,7 @@ export default class Service {
     this._sws = Sws
     this._serviceUri = ''
     this._lastRequest = null
+    this._requestAdapter = null
 
     this._invalidAccessTokenHandler = handleFetchError
     this._invalidRefreshTokenHandler = handleFetchError
@@ -120,6 +121,12 @@ export default class Service {
       responseType,
       headers
     )
+
+    if (this.requestAdapter) {
+      // Custom request handler: should return a promise and supply a valid response
+      this._lastRequest.adapter = this.requestAdapter
+    }
+
     return this.fetchRequest(this._lastRequest)
   }
 
@@ -134,7 +141,6 @@ export default class Service {
       .then((response) => { return response.data })
       .catch((err) => {
         err.client = this
-
         if (err.code === 'ECONNABORTED') {
           // Timeout
           return Promise.resolve(this.timeoutExceededHandler(err))
@@ -269,6 +275,23 @@ export default class Service {
    */
   get serviceUnavailableHandler () {
     return this._serviceUnavailableHandler
+  }
+
+  /**
+   * Set the axios request adapter
+   * @param {function} f Callback
+   * @return {void}
+   */
+  set requestAdapter (f) {
+    this._requestAdapter = f
+  }
+
+  /**
+   * Get the axios request adapter
+   * @return {function}
+   */
+  get requestAdapter () {
+    return this._requestAdapter
   }
 
   /**

--- a/src/Sws.js
+++ b/src/Sws.js
@@ -129,6 +129,18 @@ export default class Sws {
   }
 
   /**
+   * Sets the axios request adapter for all clients
+   *
+   * @param {Function} f Callback function
+   * @return {Void}
+   */
+  setRequestAdapter (f) {
+    for (let service in this._service) {
+      this._service[service].requestAdapter = f
+    }
+  }
+
+  /**
    * Get the client application ID
    *
    * @return {String} Application ID

--- a/test/spec/ServiceTest.js
+++ b/test/spec/ServiceTest.js
@@ -276,4 +276,13 @@ describe('Service', function () {
       )
     })
   })
+
+  it('tests that setting a custom request adapter results in that adapter handling axios requests', function () {
+    let sws = new Sws({ appId: appId })
+    const expected = 'A value'
+    sws.license.requestAdapter = () => Promise.resolve({ data: expected })
+    return sws.license.getLicenses().then(response => {
+      expect(response).to.equal(expected)
+    }, () => Promise.reject(new Error('Expected promise to resolve successfully')))
+  })
 })

--- a/test/spec/SwsTest.js
+++ b/test/spec/SwsTest.js
@@ -78,4 +78,11 @@ describe('Sws', function () {
     sws.setTimesoutExceededHandler(customErrorHandler)
     expect(customErrorHandler).to.equal(sws.license.timeoutExceededHandler)
   })
+
+  it('tests that `setRequestAdapter` sets the correct axios request adapter for a service client', function () {
+    let customRequestAdapter = () => { return 'A value' }
+    let sws = new Sws({ appId: appId })
+    sws.setRequestAdapter(customRequestAdapter)
+    expect(customRequestAdapter).to.equal(sws.license.requestAdapter)
+  })
 })


### PR DESCRIPTION
Add the option to set a custom request adapter (an axios feature). Adapters should return a promise and supply a valid response.

For load testing, we want to construct requests but not send them (as requests are made through k6). With these changes, setting the adapter to `() => Promise.resolve({})` achieves this. The load tests can then access `lastRequest`, and adapt that to k6's request method(s). Open to suggestions of better ways to do this.