### PR TITLE
[WEB-7726] Fix access denied handler and prevent multiple concurrent access token refreshes on auto-refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serato/sws-sdk",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "description": "Serato Web Services JS SDK",
   "main": "src/index.js",
   "types": "types/index.d.ts",

--- a/src/Service.js
+++ b/src/Service.js
@@ -40,6 +40,8 @@ export default class Service {
     this._serviceErrorHandler = handleFetchError
     /** @private */
     this._serviceUnavailableHandler = handleFetchError
+    /** @private */
+    this._defaultErrorHandler = handleFetchError
   }
 
   /**
@@ -311,6 +313,14 @@ export default class Service {
    */
   get serviceUnavailableHandler () {
     return this._serviceUnavailableHandler
+  }
+
+  /**
+   * Gets the default error handler callback
+   * @return { import("./Sws").RequestErrorHandler }
+   */
+  get defaultErrorHandler () {
+    return this._defaultErrorHandler
   }
 
   /**

--- a/src/SwsClient.js
+++ b/src/SwsClient.js
@@ -45,11 +45,14 @@ export default class SwsClient extends Sws {
     this.setInvalidAccessTokenHandler(this.fetchNewAccessTokenAndRetryRequest())
 
     this.setAccessDeniedHandler((request, err) => {
+      const client = err.client
       // Could be that we haven't set the access token (ie. on first page load)
-      if (this.accessToken === '') {
+      if (this.accessToken === '' && this.refreshToken !== '') {
+        // Try refreshing the access token and retrying
         const fn = this.fetchNewAccessTokenAndRetryRequest()
-        fn(request, err)
+        return fn(request, err)
       }
+      return client.defaultErrorHandler(request, err)
     })
   }
 

--- a/types/Service.d.ts
+++ b/types/Service.d.ts
@@ -10,6 +10,7 @@ export default class Service {
     private _timeoutExceededHandler;
     private _serviceErrorHandler;
     private _serviceUnavailableHandler;
+    private _defaultErrorHandler;
     protected bearerTokenAuthHeader(): string;
     protected basicAuthHeader(): string;
     protected toBody(data: import("./Sws").RequestParams): import("./Sws").RequestParams;
@@ -31,6 +32,7 @@ export default class Service {
     get serviceErrorHandler(): import("./Sws").RequestErrorHandler;
     set serviceUnavailableHandler(arg: import("./Sws").RequestErrorHandler);
     get serviceUnavailableHandler(): import("./Sws").RequestErrorHandler;
+    get defaultErrorHandler(): import("./Sws").RequestErrorHandler;
     get lastRequest(): import("./Sws").Request;
 }
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'OPTIONS';

--- a/types/SwsClient.d.ts
+++ b/types/SwsClient.d.ts
@@ -1,5 +1,6 @@
 export default class SwsClient extends Sws {
     private _accessTokenUpdatedHandler;
+    private _accessTokenRefreshPromise;
     public createAuthorizationRequest(redirectUrl: string, refreshTokenId?: string): Promise<AuthorizationRequest>;
     set accessTokenUpdatedHandler(arg: AccessTokenUpdatedHandler);
     get accessTokenUpdatedHandler(): AccessTokenUpdatedHandler;


### PR DESCRIPTION
- Default access denied handler now returns a promise if an auto-refresh is invoked within it. Else it will invoke the default error handler
- The auto-refresh mechanism was modified such that only one access token refresh can be in flight at a time. This is implemented by storing a promise which is resolved after the refresh has concluded and its results stored in the client. Any failed requests while this promise is stored will await this promise before reattempting the request.