### PR TITLE
[WEB-8862] Update JS SDK - Cart API endpoints

### DIFF
--- a/src/Ecom.js
+++ b/src/Ecom.js
@@ -198,7 +198,7 @@ import Service from './Service'
  * @typedef {Object} RecommendationsList
  * @property {CatalogProduct[]} items
  *
- * @typedef {Object} BillingAddress
+ * @typedef {Object} CartBillingAddress
  * @property {String} [first_name = undefined]
  * @property {String} [last_name = undefined]
  * @property {String} [company = undefined]
@@ -216,7 +216,6 @@ import Service from './Service'
  * @property {String} [end_date = undefined] The date the promotion ends.
  *
  * @typedef {Object} ProductType
- * @property {CatalogProduct[]} items
  * @property {Number} id
  * @property {String} name
  * @property {String} [subscription_start_date = undefined] The start date/time of the subscription product. It will be presented only if the start date/time is in the future.
@@ -231,7 +230,6 @@ import Service from './Service'
  * @property {Number} total_amount
  * @property {Number} tax_amount
  * @property {Number} tax_rate
- * @property {Number} [total_amount_after_promotion = undefined] The total amount of the cart item after the promotion is applied. It will be presented only if there is a promotion applied to the cart item.
  * @property {Number} [error_code = undefined] If present, proceeding with the purchase will not be possible with the item in the cart.
  * @property {String} [subscription_start_date = undefined] The start date/time of the subscription product. It will be presented only if the start date/time is in the future.
  * @property {Number} [prepaid_credit_in_days = undefined] The number of days that the user has credit for the product they are subscribing to.
@@ -247,7 +245,7 @@ import Service from './Service'
  * @property {String} currency 3 letter currency code (ISO 4217).
  * @property {String} created_at The date/time the cart was created in ISO 8061 format.
  * @property {String} updated_at The date/time the cart was updated in ISO 8061 format.
- * @property {BillingAddress} [billing_address = undefined]
+ * @property {CartBillingAddress} [billing_address = undefined]
  * @property {String} [coupon_code = undefined] The coupon code for the promotion.
  *
  * @typedef {Object} ProductItem
@@ -651,7 +649,7 @@ export default class EcomService extends Service {
    *
    * @param {Object} param Options
    * @param {String} param.cartId
-   * @param {Omit<BillingAddress, 'country_code'>} param.billingAddress
+   * @param {Omit<CartBillingAddress, 'country_code'>} param.billingAddress
    * @return {Promise<Cart>}
    */
   updateCartBillingAddress ({ cartId, billingAddress }) {

--- a/src/Ecom.js
+++ b/src/Ecom.js
@@ -657,7 +657,7 @@ export default class EcomService extends Service {
    * @return {Promise}
    */
   updateCart ({ cartId, billingAddress, couponCode} = {}) {
-    if (billing_address) {
+    if (billingAddress) {
       return this.fetch(
         this._sws.accessToken ? this.bearerTokenAuthHeader() : null,
         '/api/v1/carts/' + cartId,
@@ -666,7 +666,7 @@ export default class EcomService extends Service {
         }),
         'PUT'
       )
-    } else if (coupon_code) {
+    } else if (couponCode) {
       return this.fetch(
         this._sws.accessToken ? this.bearerTokenAuthHeader() : null,
         '/api/v1/carts/' + cartId,

--- a/src/Ecom.js
+++ b/src/Ecom.js
@@ -645,4 +645,36 @@ export default class EcomService extends Service {
       'POST'
     )
   }
+
+  /**
+   * Updates cart by a given cart id.
+   * One of coupon_code or billing_address must be provided in the body, but not both.
+   *
+   * @param {Object} param Options
+   * @param {String} param.cartId
+   * @param {Omit<BillingAddress, 'country_code'>} param.billingAddress
+   * @param {String} param.couponCode
+   * @return {Promise}
+   */
+  updateCart ({ cartId, billingAddress, couponCode} = {}) {
+    if (billing_address) {
+      return this.fetch(
+        this._sws.accessToken ? this.bearerTokenAuthHeader() : null,
+        '/api/v1/carts/' + cartId,
+        this.toBody({
+          billing_address: billingAddress,
+        }),
+        'PUT'
+      )
+    } else if (coupon_code) {
+      return this.fetch(
+        this._sws.accessToken ? this.bearerTokenAuthHeader() : null,
+        '/api/v1/carts/' + cartId,
+        this.toBody({
+          coupon_code: couponCode,
+        }),
+        'PUT'
+      )
+    }
+  }
 }

--- a/src/Ecom.js
+++ b/src/Ecom.js
@@ -197,7 +197,7 @@ import Service from './Service'
  *
  * @typedef {Object} RecommendationsList
  * @property {CatalogProduct[]} items
- * 
+ *
  * @typedef {Object} BillingAddress
  * @property {String} [first_name = undefined]
  * @property {String} [last_name = undefined]
@@ -208,13 +208,13 @@ import Service from './Service'
  * @property {String} [post_code = undefined]
  * @property {String} [region = undefined]
  * @property {String} country_code
- * 
+ *
  * @typedef {Object} Promotion
  * @property {String} description The description for the promotion that is applied to the cart item.
  * @property {String} [discount_fixed_amount = undefined] The fixed amount discount that is applied to the cart item. It will be presented only if the promotion is `fixed-amount`.
  * @property {Number} [discount_percentage = undefined] The percentage discount that is applied to the cart item. It will be presented only if the promotion is `percentage`.
  * @property {String} [end_date = undefined] The date the promotion ends.
- * 
+ *
  * @typedef {Object} ProductType
  * @property {CatalogProduct[]} items
  * @property {Number} id
@@ -222,7 +222,7 @@ import Service from './Service'
  * @property {String} [subscription_start_date = undefined] The start date/time of the subscription product. It will be presented only if the start date/time is in the future.
  * @property {Number} [subscription_billing_period = undefined] The billing period of the subscription product. It will be presented only if the product is a subscription.
  * @property {Number} [prepaid_credit_in_days = undefined] The number of days that the user has credit for the product they are subscribing to.
- * 
+ *
  * @typedef {Object} CartItem
  * @property {Number} id
  * @property {ProductType} product_type
@@ -237,19 +237,19 @@ import Service from './Service'
  * @property {Number} [prepaid_credit_in_days = undefined] The number of days that the user has credit for the product they are subscribing to.
  * @property {Number} [subscription_billing_period = undefined] The billing period of the subscription product. It will be presented only if the product is a subscription.
  * @property {Promotion[]} [promotion = undefined] The promotion that is applied to the cart item.
-
+ *
  * @typedef {Object} Cart
  * @property {String} uuid The cart universal unique ID.
  * @property {CartItem[]} items
  * @property {Number} total_amount
- * @property {Number} subtotal_amount 
+ * @property {Number} subtotal_amount
  * @property {Number} tax_amount
  * @property {String} currency 3 letter currency code (ISO 4217).
  * @property {String} created_at The date/time the cart was created in ISO 8061 format.
  * @property {String} updated_at The date/time the cart was updated in ISO 8061 format.
  * @property {BillingAddress} [billing_address = undefined]
  * @property {String} [coupon_code = undefined] The coupon code for the promotion.
- * 
+ *
  * @typedef {Object} ProductItem
  * @property {Number} product_type_id
  * @property {Number} quantity
@@ -654,12 +654,12 @@ export default class EcomService extends Service {
    * @param {Omit<BillingAddress, 'country_code'>} param.billingAddress
    * @return {Promise<Cart>}
    */
-  updateCartBillingAddress ({ cartId, billingAddress}) {
+  updateCartBillingAddress ({ cartId, billingAddress }) {
     return this.fetch(
       this._sws.accessToken ? this.bearerTokenAuthHeader() : null,
       '/api/v1/carts/' + cartId,
       this.toBody({
-        billing_address: billingAddress,
+        billing_address: billingAddress
       }),
       'PUT'
     )
@@ -673,12 +673,12 @@ export default class EcomService extends Service {
    * @param {String} param.couponCode
    * @return {Promise<Cart>}
    */
-  updateCartCouponCode ({ cartId, couponCode}) {
+  updateCartCouponCode ({ cartId, couponCode }) {
     return this.fetch(
       this._sws.accessToken ? this.bearerTokenAuthHeader() : null,
       '/api/v1/carts/' + cartId,
       this.toBody({
-        coupon_code: couponCode,
+        coupon_code: couponCode
       }),
       'PUT'
     )

--- a/src/Ecom.js
+++ b/src/Ecom.js
@@ -249,6 +249,10 @@ import Service from './Service'
  * @property {String} updated_at The date/time the cart was updated in ISO 8061 format.
  * @property {BillingAddress} [billing_address = undefined]
  * @property {String} [coupon_code = undefined] The coupon code for the promotion.
+ * 
+ * @typedef {Object} ProductItem
+ * @property {String} product_type_id
+ * @property {Number} quantity
  */
 
 /**
@@ -611,6 +615,7 @@ export default class EcomService extends Service {
 
   /**
    * Returns a cart by a given cart uuid.
+   * @param {Object} param Options
    * @param {String} param.cartId
    * @returns {Promise<Cart> }
    */
@@ -619,6 +624,25 @@ export default class EcomService extends Service {
       this._sws.accessToken ? this.bearerTokenAuthHeader() : null,
       '/api/v1/carts/' + cartId,
       null
+    )
+  }
+
+  /**
+   * Creates a cart.
+   * @param {Object} param Options
+   * @param {ProductItem[]} param.products
+   * @param {String} param.couponCode
+   * @returns {Promise<Cart> }
+   */
+  createCart ({ products, couponCode }) {
+    return this.fetch(
+      this._sws.accessToken ? this.bearerTokenAuthHeader() : null,
+      '/api/v1/carts',
+      this.toBody({
+        products: products,
+        coupon_code: couponCode
+      }),
+      'POST'
     )
   }
 }

--- a/src/Ecom.js
+++ b/src/Ecom.js
@@ -620,7 +620,7 @@ export default class EcomService extends Service {
   getCart ({ cartId }) {
     return this.fetch(
       this._sws.accessToken ? this.bearerTokenAuthHeader() : null,
-      '/api/v1/carts/' + cartId,
+      `/api/v1/carts/${cartId}`,
       null
     )
   }
@@ -655,7 +655,7 @@ export default class EcomService extends Service {
   updateCartBillingAddress ({ cartId, billingAddress }) {
     return this.fetch(
       this._sws.accessToken ? this.bearerTokenAuthHeader() : null,
-      '/api/v1/carts/' + cartId,
+      `/api/v1/carts/${cartId}`,
       this.toBody({
         billing_address: billingAddress
       }),
@@ -674,7 +674,7 @@ export default class EcomService extends Service {
   updateCartCouponCode ({ cartId, couponCode }) {
     return this.fetch(
       this._sws.accessToken ? this.bearerTokenAuthHeader() : null,
-      '/api/v1/carts/' + cartId,
+      `/api/v1/carts/${cartId}`,
       this.toBody({
         coupon_code: couponCode
       }),

--- a/src/Ecom.js
+++ b/src/Ecom.js
@@ -251,7 +251,7 @@ import Service from './Service'
  * @property {String} [coupon_code = undefined] The coupon code for the promotion.
  * 
  * @typedef {Object} ProductItem
- * @property {String} product_type_id
+ * @property {Number} product_type_id
  * @property {Number} quantity
  */
 

--- a/src/Ecom.js
+++ b/src/Ecom.js
@@ -647,34 +647,40 @@ export default class EcomService extends Service {
   }
 
   /**
-   * Updates cart by a given cart id.
-   * One of coupon_code or billing_address must be provided in the body, but not both.
+   * Updates a cart billing address by a given cart id.
    *
    * @param {Object} param Options
    * @param {String} param.cartId
    * @param {Omit<BillingAddress, 'country_code'>} param.billingAddress
-   * @param {String} param.couponCode
-   * @return {Promise}
+   * @return {Promise<Cart>}
    */
-  updateCart ({ cartId, billingAddress, couponCode} = {}) {
-    if (billingAddress) {
-      return this.fetch(
-        this._sws.accessToken ? this.bearerTokenAuthHeader() : null,
-        '/api/v1/carts/' + cartId,
-        this.toBody({
-          billing_address: billingAddress,
-        }),
-        'PUT'
-      )
-    } else if (couponCode) {
-      return this.fetch(
-        this._sws.accessToken ? this.bearerTokenAuthHeader() : null,
-        '/api/v1/carts/' + cartId,
-        this.toBody({
-          coupon_code: couponCode,
-        }),
-        'PUT'
-      )
-    }
+  updateCartBillingAddress ({ cartId, billingAddress}) {
+    return this.fetch(
+      this._sws.accessToken ? this.bearerTokenAuthHeader() : null,
+      '/api/v1/carts/' + cartId,
+      this.toBody({
+        billing_address: billingAddress,
+      }),
+      'PUT'
+    )
+  }
+
+  /**
+   * Updates a carts coupon code by a given cart id.
+   *
+   * @param {Object} param Options
+   * @param {String} param.cartId
+   * @param {String} param.couponCode
+   * @return {Promise<Cart>}
+   */
+  updateCartCouponCode ({ cartId, couponCode}) {
+    return this.fetch(
+      this._sws.accessToken ? this.bearerTokenAuthHeader() : null,
+      '/api/v1/carts/' + cartId,
+      this.toBody({
+        coupon_code: couponCode,
+      }),
+      'PUT'
+    )
   }
 }

--- a/src/Ecom.js
+++ b/src/Ecom.js
@@ -197,6 +197,58 @@ import Service from './Service'
  *
  * @typedef {Object} RecommendationsList
  * @property {CatalogProduct[]} items
+ * 
+ * @typedef {Object} BillingAddress
+ * @property {String} [first_name = undefined]
+ * @property {String} [last_name = undefined]
+ * @property {String} [company = undefined]
+ * @property {String} [address = undefined]
+ * @property {String} [address_extended = undefined]
+ * @property {String} [city = undefined]
+ * @property {String} [post_code = undefined]
+ * @property {String} [region = undefined]
+ * @property {String} country_code
+ * 
+ * @typedef {Object} Promotion
+ * @property {String} description The description for the promotion that is applied to the cart item.
+ * @property {String} [discount_fixed_amount = undefined] The fixed amount discount that is applied to the cart item. It will be presented only if the promotion is `fixed-amount`.
+ * @property {Number} [discount_percentage = undefined] The percentage discount that is applied to the cart item. It will be presented only if the promotion is `percentage`.
+ * @property {String} [end_date = undefined] The date the promotion ends.
+ * 
+ * @typedef {Object} ProductType
+ * @property {CatalogProduct[]} items
+ * @property {Number} id
+ * @property {String} name
+ * @property {String} [subscription_start_date = undefined] The start date/time of the subscription product. It will be presented only if the start date/time is in the future.
+ * @property {Number} [subscription_billing_period = undefined] The billing period of the subscription product. It will be presented only if the product is a subscription.
+ * @property {Number} [prepaid_credit_in_days = undefined] The number of days that the user has credit for the product they are subscribing to.
+ * 
+ * @typedef {Object} CartItem
+ * @property {Number} id
+ * @property {ProductType} product_type
+ * @property {Number} quantity
+ * @property {Number} base_amount
+ * @property {Number} total_amount
+ * @property {Number} tax_amount
+ * @property {Number} tax_rate
+ * @property {Number} [total_amount_after_promotion = undefined] The total amount of the cart item after the promotion is applied. It will be presented only if there is a promotion applied to the cart item.
+ * @property {Number} [error_code = undefined] If present, proceeding with the purchase will not be possible with the item in the cart.
+ * @property {String} [subscription_start_date = undefined] The start date/time of the subscription product. It will be presented only if the start date/time is in the future.
+ * @property {Number} [prepaid_credit_in_days = undefined] The number of days that the user has credit for the product they are subscribing to.
+ * @property {Number} [subscription_billing_period = undefined] The billing period of the subscription product. It will be presented only if the product is a subscription.
+ * @property {Promotion[]} [promotion = undefined] The promotion that is applied to the cart item.
+
+ * @typedef {Object} Cart
+ * @property {String} uuid The cart universal unique ID.
+ * @property {CartItem[]} items
+ * @property {Number} total_amount
+ * @property {Number} subtotal_amount 
+ * @property {Number} tax_amount
+ * @property {String} currency 3 letter currency code (ISO 4217).
+ * @property {String} created_at The date/time the cart was created in ISO 8061 format.
+ * @property {String} updated_at The date/time the cart was updated in ISO 8061 format.
+ * @property {BillingAddress} [billing_address = undefined]
+ * @property {String} [coupon_code = undefined] The coupon code for the promotion.
  */
 
 /**
@@ -554,6 +606,19 @@ export default class EcomService extends Service {
         catalog_category: catalogCategory
       }),
       'GET'
+    )
+  }
+
+  /**
+   * Returns a cart by a given cart uuid.
+   * @param {String} param.cartId
+   * @returns {Promise<Cart> }
+   */
+  getCart ({ cartId }) {
+    return this.fetch(
+      this._sws.accessToken ? this.bearerTokenAuthHeader() : null,
+      '/api/v1/carts/' + cartId,
+      null
     )
   }
 }

--- a/test/integration/EcomTest.js
+++ b/test/integration/EcomTest.js
@@ -406,6 +406,21 @@ describe('Ecom Tests', function () {
           }
         )
       }
+    ),
+    it(`confirms URI used in 'createCart()' method with no user ID, with products param by returning a non-404 HTTP response`,
+      function () {
+        return swsClient.ecom.createCart({
+          products: [{
+            product_type_id: 0,
+            quantity: 1
+          }]
+        }).then(
+          () => Promise.reject(new Error('Expected non-2xx HTTP response code')),
+          err => {
+            expect(err.httpStatus).not.to.equal(404)
+          }
+        )
+      }
     )
   })
 })

--- a/types/Ecom.d.ts
+++ b/types/Ecom.d.ts
@@ -60,7 +60,7 @@ export default class EcomService extends Service {
     }): Promise<Ecom.Cart>;
     updateCartBillingAddress({ cartId, billingAddress }: {
         cartId: string;
-        billingAddress?: Omit<Ecom.BillingAddress, 'country_code'>;
+        billingAddress?: Omit<Ecom.CartBillingAddress, 'country_code'>;
     }): Promise<Ecom.Cart>;
     updateCartCouponCode({ cartId, couponCode }: {
         cartId: string;
@@ -262,7 +262,7 @@ export namespace Ecom {
     export type RecommendationsList = {
         items: CatalogProduct[];
     };
-    export type BillingAddress = {
+    export type CartBillingAddress = {
         first_name?: string;
         last_name?: string;
         company?: string;
@@ -294,7 +294,6 @@ export namespace Ecom {
         total_amount: number;
         tax_amount: number;
         tax_rate: number;
-        total_amount_after_promotion?: number;
         error_code?: number;
         subscription_start_date?: string;
         prepaid_credit_in_days?: number;
@@ -310,7 +309,7 @@ export namespace Ecom {
         currency: string;
         created_at: string;
         updated_at: string;
-        billing_address?: BillingAddress;
+        billing_address?: CartBillingAddress;
         coupon_code?: string;
     };
     export type ProductItem = {

--- a/types/Ecom.d.ts
+++ b/types/Ecom.d.ts
@@ -311,7 +311,7 @@ export namespace Ecom {
         coupon_code?: string;
     };
     export type ProductItem = {
-        product_type_id: string;
+        product_type_id: number;
         quantity: number;
     };
 }

--- a/types/Ecom.d.ts
+++ b/types/Ecom.d.ts
@@ -58,10 +58,13 @@ export default class EcomService extends Service {
         products: Ecom.ProductItem[];
         couponCode?: string;
     }): Promise<Ecom.Cart>;
-    updateCart({ cartId, couponCode, billingAddress }: {
+    updateCartBillingAddress({ cartId, billingAddress }: {
+        cartId: string;
+        billingAddress?: Omit<Ecom.BillingAddress, 'country_code'>;
+    }): Promise<Ecom.Cart>;
+    updateCartCouponCode({ cartId, couponCode }: {
         cartId: string;
         couponCode?: string;
-        billingAddress?: Omit<Ecom.BillingAddress, 'country_code'>;
     }): Promise<Ecom.Cart>;
 }
 export namespace Ecom {

--- a/types/Ecom.d.ts
+++ b/types/Ecom.d.ts
@@ -58,6 +58,11 @@ export default class EcomService extends Service {
         products: Ecom.ProductItem[];
         couponCode?: string;
     }): Promise<Ecom.Cart>;
+    updateCart({ cartId, couponCode, billingAddress }: {
+        cartId: string;
+        couponCode?: string;
+        billingAddress?: Omit<Ecom.BillingAddress, 'country_code'>;
+    }): Promise<Ecom.Cart>;
 }
 export namespace Ecom {
     export type SubscriptionGroup = 'dj' | 'wailshark' | 'sample' | 'serato_studio';

--- a/types/Ecom.d.ts
+++ b/types/Ecom.d.ts
@@ -51,8 +51,12 @@ export default class EcomService extends Service {
         appVersion?: string;
         catalogCategory?: string;
     }): Promise<Ecom.RecommendationsList>;
-    getCart({ cartId }?: {
+    getCart({ cartId }: {
         cartId: string;
+    }): Promise<Ecom.Cart>;
+    createCart({ products, couponCode }: {
+        products: Ecom.ProductItem[];
+        couponCode?: string;
     }): Promise<Ecom.Cart>;
 }
 export namespace Ecom {
@@ -300,6 +304,10 @@ export namespace Ecom {
         updated_at: string;
         billing_address?: BillingAddress;
         coupon_code?: string;
+    };
+    export type ProductItem = {
+        product_type_id: string;
+        quantity: number;
     };
 }
 import Service from "./Service";

--- a/types/Ecom.d.ts
+++ b/types/Ecom.d.ts
@@ -51,6 +51,9 @@ export default class EcomService extends Service {
         appVersion?: string;
         catalogCategory?: string;
     }): Promise<Ecom.RecommendationsList>;
+    getCart({ cartId }?: {
+        cartId: string;
+    }): Promise<Ecom.Cart>;
 }
 export namespace Ecom {
     export type SubscriptionGroup = 'dj' | 'wailshark' | 'sample' | 'serato_studio';
@@ -246,6 +249,57 @@ export namespace Ecom {
     };
     export type RecommendationsList = {
         items: CatalogProduct[];
+    };
+    export type BillingAddress = {
+        first_name?: string;
+        last_name?: string;
+        company?: string;
+        address?: string;
+        address_extended?: string;
+        city?: string;
+        post_code?: string;
+        region?: string;
+        country_code: string;
+    };
+    export type Promotion = {
+        description: string;
+        discount_fixed_amount?: string;
+        discount_percentage?: number;
+        end_date?: string;
+    };
+    export type ProductType = {
+        id: number;
+        name: string;
+        subscription_start_date?: string;
+        subscription_billing_period?: number;
+        prepaid_credit_in_days?: number;
+    };
+    export type CartItem = {
+        id: number;
+        product_type: ProductType;
+        quantity: number;
+        base_amount: number;
+        total_amount: number;
+        tax_amount: number;
+        tax_rate: number;
+        total_amount_after_promotion?: number;
+        error_code?: number;
+        subscription_start_date?: string;
+        prepaid_credit_in_days?: number;
+        subscription_billing_period?: number;
+        promotion?: Promotion[];
+    };
+    export type Cart = {
+        uuid: string;
+        items: CartItem[];
+        total_amount: number;
+        subtotal_amount: number;
+        tax_amount: number;
+        currency: string;
+        created_at: string;
+        updated_at: string;
+        billing_address?: BillingAddress;
+        coupon_code?: string;
     };
 }
 import Service from "./Service";


### PR DESCRIPTION
Add functions for creating, updating and retrieving a cart on the Ecom Service

I didn't write integration smoke tests for the GET and PUT endpoints, since it seems all the tests check to see if the url **does not** return a 404, whereas these would because it's part of the behaviour of the endpoint. Thus making it redundant to check if the uri works.