### PR TITLE
[WEB-10052] Ecom 2.0 cart promotion end_date property is the wrong value

### DIFF
--- a/src/Ecom.js
+++ b/src/Ecom.js
@@ -213,7 +213,7 @@ import Service from './Service'
  * @property {String} description The description for the promotion that is applied to the cart item.
  * @property {Number} [discount_fixed_amount = undefined] The fixed amount discount that is applied to the cart item. It will be presented only if the promotion is `fixed-amount`.
  * @property {Number} [discount_percentage = undefined] The percentage discount that is applied to the cart item. It will be presented only if the promotion is `percentage`.
- * @property {String} [end_date = undefined] The date the promotion ends.
+ * @property {Number} [billing_cycle_duration = undefined] The number of billing cycles the promotion is applied for.
  *
  * @typedef {Object} ProductType
  * @property {Number} id

--- a/types/Ecom.d.ts
+++ b/types/Ecom.d.ts
@@ -277,7 +277,7 @@ export namespace Ecom {
         description: string;
         discount_fixed_amount?: number;
         discount_percentage?: number;
-        end_date?: string;
+        billing_cycle_duration?: number;
     };
     export type ProductType = {
         id: number;


### PR DESCRIPTION
Update property for Promotions. 
Return `promotion.billing_cycle_duration` in cart instead of `promotion.end_date`