### PR TITLE
[WEB-10519] - Update JS SDK to allow for Assets endpoint to be accessed with basic auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serato/sws-sdk",
-  "version": "6.13.0",
+  "version": "6.14.0",
   "description": "Serato Web Services JS SDK",
   "main": "src/index.js",
   "types": "types/index.d.ts",

--- a/src/DigitalAssets.js
+++ b/src/DigitalAssets.js
@@ -102,7 +102,7 @@ export default class DigitalAssetsService extends Service {
    */
   get ({ hostAppName, hostAppVersion, hostOs, type, releaseType, releaseDate, latestOnly } = {}) {
     return this.fetch(
-      this.bearerTokenOrBasicAuthHeader(),
+      this.basicAuthHeader(),
       '/api/v1/assets',
       this.toBody({
         host_app_name: hostAppName,

--- a/src/DigitalAssets.js
+++ b/src/DigitalAssets.js
@@ -102,7 +102,7 @@ export default class DigitalAssetsService extends Service {
    */
   get ({ hostAppName, hostAppVersion, hostOs, type, releaseType, releaseDate, latestOnly } = {}) {
     return this.fetch(
-      this.basicAuthHeader(),
+      this.bearerTokenOrBasicAuthHeader(),
       '/api/v1/assets',
       this.toBody({
         host_app_name: hostAppName,

--- a/src/DigitalAssets.js
+++ b/src/DigitalAssets.js
@@ -106,18 +106,9 @@ export default class DigitalAssetsService extends Service {
    * @return {Promise<AssetList>}
    */
   get ({ hostAppName, hostAppVersion, hostOs, type, releaseType, releaseDate, latestOnly } = {}) {
-    const headers = {
-      Accept: 'application/json',
-      'Content-Type': 'application/json'
-    }
-
-    if (!this._sws.accessToken) {
-      headers['x-serato-cdn-auth'] = this.xSeratoCdnAuthHeader()
-    }
-
     // If an access token is present, use bearer token. If no access token, return use basic auth header
     return this.fetch(
-      this._sws.accessToken ? this.bearerTokenAuthHeader() : this.basicAuthHeader(),
+      this.bearerTokenAuthHeader(),
       '/api/v1/assets',
       this.toBody({
         host_app_name: hostAppName,
@@ -128,10 +119,7 @@ export default class DigitalAssetsService extends Service {
         release_date: releaseDate,
         latest_only: latestOnly
       }),
-      'GET',
-      null,
-      'json',
-      headers
+      'GET'
     )
   }
 

--- a/src/DigitalAssets.js
+++ b/src/DigitalAssets.js
@@ -106,19 +106,32 @@ export default class DigitalAssetsService extends Service {
    * @return {Promise<AssetList>}
    */
   get ({ hostAppName, hostAppVersion, hostOs, type, releaseType, releaseDate, latestOnly } = {}) {
+    const headers = {
+      Accept: 'application/json',
+      'Content-Type': 'application/json'
+    }
+
+    if (!this._sws.accessToken) {
+      headers['x-serato-cdn-auth'] = this.xSeratoCdnAuthHeader()
+    }
+
+    // If an access token is present, use bearer token. If no access token, return use basic auth header
     return this.fetch(
-      this.bearerTokenOrBasicAuthHeader(),
+      this._sws.accessToken ? this.bearerTokenAuthHeader() : this.basicAuthHeader(),
       '/api/v1/assets',
       this.toBody({
         host_app_name: hostAppName,
         host_app_version: hostAppVersion,
         host_app_os: hostOs,
-        type: type,
+        type,
         release_type: releaseType,
         release_date: releaseDate,
         latest_only: latestOnly
       }),
-      'GET'
+      'GET',
+      null,
+      'json',
+      headers
     )
   }
 

--- a/src/DigitalAssets.js
+++ b/src/DigitalAssets.js
@@ -102,7 +102,7 @@ export default class DigitalAssetsService extends Service {
    */
   get ({ hostAppName, hostAppVersion, hostOs, type, releaseType, releaseDate, latestOnly } = {}) {
     return this.fetch(
-      this.bearerTokenAuthHeader(),
+      this.bearerTokenOrBasicAuthHeader(),
       '/api/v1/assets',
       this.toBody({
         host_app_name: hostAppName,

--- a/src/Service.js
+++ b/src/Service.js
@@ -56,6 +56,10 @@ export default class Service {
     return 'Bearer ' + this._sws.accessToken
   }
 
+  xSeratoCdnAuthHeader () {
+    return Base64.encode(this._sws.appId + ':' + this._sws.appSecret)
+  }
+
   /**
    * Returns an `Authorisation` header value comprised of
    * an application ID and secret
@@ -66,26 +70,6 @@ export default class Service {
    */
   basicAuthHeader () {
     return 'Basic ' + Base64.encode(this._sws.appId + ':' + this._sws.appSecret)
-  }
-
-  /**
-   * Returns an `Authorisation` header value comprised of
-   * either a bearer token or an application ID and secret
-   * depending which is available
-   *
-   * @protected
-   *
-   * @return {String} Auth header value
-   */
-  bearerTokenOrBasicAuthHeader () {
-    let header = ''
-    // If an access token is present, return a bearer token
-    if (!!this._sws.accessToken) {
-      header = this.bearerTokenAuthHeader()
-    } else { // If no access token, return a basic auth header
-      header = this.basicAuthHeader()
-    }
-    return header
   }
 
   /**

--- a/src/Service.js
+++ b/src/Service.js
@@ -79,9 +79,10 @@ export default class Service {
    */
   bearerTokenOrBasicAuthHeader () {
     let header = ''
-    if (this._sws.accessToken !== undefined) {
+    // If an access token is present, return a bearer token
+    if (!!this._sws.accessToken) {
       header = this.bearerTokenAuthHeader()
-    } else {
+    } else { // If no access token, return a basic auth header
       header = this.basicAuthHeader()
     }
     return header

--- a/src/Service.js
+++ b/src/Service.js
@@ -119,7 +119,7 @@ export default class Service {
     }
   ) {
     this._lastRequest = buildRequest(
-      this._sws,
+      this,
       auth,
       (this.serviceUri.indexOf('://') === -1 ? 'https://' : '') + this.serviceUri + endpoint,
       body,
@@ -363,7 +363,7 @@ function handleFetchError (request, err) {
 
 /**
  * Constructs a Request object
- * @param  {String} sws sws Service object.
+ * @param  {String} service Service object.
  * @param  {String} auth Authorisation header value
  * @param  {String} endpoint API endpoint
  * @param  { import("./Sws").RequestParams } body Object to send in the body
@@ -373,7 +373,7 @@ function handleFetchError (request, err) {
  * @param  { import("./Sws").RequestHeaders } headers Custom headers (defaults to Accept/Content-Type json)
  * @return { import("./Sws").Request }
  */
-function buildRequest (sws, auth, endpoint, body, method, timeout, responseType, headers) {
+function buildRequest (service, auth, endpoint, body, method, timeout, responseType, headers) {
   const request = {
     timeout,
     url: endpoint,
@@ -382,9 +382,9 @@ function buildRequest (sws, auth, endpoint, body, method, timeout, responseType,
     headers
   }
 
-  if (sws.isServerSide) {
-    request.headers['x-serato-cdn-auth'] = sws.xSeratoCdnAuthHeader()
-    request.headers.Authorization = sws.basicAuthHeader()
+  if (service._sws.isServerSide) {
+    request.headers['x-serato-cdn-auth'] = service.xSeratoCdnAuthHeader()
+    request.headers.Authorization = service.basicAuthHeader()
   } else if (auth !== null) {
     request.headers.Authorization = auth
   }

--- a/src/Service.js
+++ b/src/Service.js
@@ -80,7 +80,7 @@ export default class Service {
   bearerTokenOrBasicAuthHeader () {
     if(this._sws.accessToken) {
       return bearerTokenAuthHeader()
-    } else if (this._sws.appId && this._sws.appSecret) {
+    } else {
       return basicAuthHeader()
     }
   }

--- a/src/Service.js
+++ b/src/Service.js
@@ -78,7 +78,7 @@ export default class Service {
    * @return {String} Auth header value
    */
   bearerTokenOrBasicAuthHeader () {
-    if(this._sws.accessToken) {
+    if (this._sws.accessToken !== undefined) {
       return bearerTokenAuthHeader()
     } else {
       return basicAuthHeader()

--- a/src/Service.js
+++ b/src/Service.js
@@ -119,6 +119,7 @@ export default class Service {
     }
   ) {
     this._lastRequest = buildRequest(
+      this._sws.isServerSide,
       auth,
       (this.serviceUri.indexOf('://') === -1 ? 'https://' : '') + this.serviceUri + endpoint,
       body,
@@ -362,7 +363,7 @@ function handleFetchError (request, err) {
 
 /**
  * Constructs a Request object
- *
+ * @param  {String} isServerSide is this request sent from server side ( eg : pre rendering)
  * @param  {String} auth Authorisation header value
  * @param  {String} endpoint API endpoint
  * @param  { import("./Sws").RequestParams } body Object to send in the body
@@ -372,7 +373,7 @@ function handleFetchError (request, err) {
  * @param  { import("./Sws").RequestHeaders } headers Custom headers (defaults to Accept/Content-Type json)
  * @return { import("./Sws").Request }
  */
-function buildRequest (auth, endpoint, body, method, timeout, responseType, headers) {
+function buildRequest (isServerSide, auth, endpoint, body, method, timeout, responseType, headers) {
   const request = {
     timeout,
     url: endpoint,
@@ -381,7 +382,7 @@ function buildRequest (auth, endpoint, body, method, timeout, responseType, head
     headers
   }
 
-  if (this._sws.isServerSide) {
+  if (isServerSide) {
     request.headers['x-serato-cdn-auth'] = this.xSeratoCdnAuthHeader()
     request.headers.Authorization = this.basicAuthHeader()
   } else if (auth !== null) {

--- a/src/Service.js
+++ b/src/Service.js
@@ -119,7 +119,7 @@ export default class Service {
     }
   ) {
     this._lastRequest = buildRequest(
-      this._sws.isServerSide,
+      this._sws,
       auth,
       (this.serviceUri.indexOf('://') === -1 ? 'https://' : '') + this.serviceUri + endpoint,
       body,
@@ -363,7 +363,7 @@ function handleFetchError (request, err) {
 
 /**
  * Constructs a Request object
- * @param  {String} isServerSide is this request sent from server side ( eg : pre rendering)
+ * @param  {String} sws sws Service object.
  * @param  {String} auth Authorisation header value
  * @param  {String} endpoint API endpoint
  * @param  { import("./Sws").RequestParams } body Object to send in the body
@@ -373,7 +373,7 @@ function handleFetchError (request, err) {
  * @param  { import("./Sws").RequestHeaders } headers Custom headers (defaults to Accept/Content-Type json)
  * @return { import("./Sws").Request }
  */
-function buildRequest (isServerSide, auth, endpoint, body, method, timeout, responseType, headers) {
+function buildRequest (sws, auth, endpoint, body, method, timeout, responseType, headers) {
   const request = {
     timeout,
     url: endpoint,
@@ -382,9 +382,9 @@ function buildRequest (isServerSide, auth, endpoint, body, method, timeout, resp
     headers
   }
 
-  if (isServerSide) {
-    request.headers['x-serato-cdn-auth'] = this.xSeratoCdnAuthHeader()
-    request.headers.Authorization = this.basicAuthHeader()
+  if (sws.isServerSide) {
+    request.headers['x-serato-cdn-auth'] = sws.xSeratoCdnAuthHeader()
+    request.headers.Authorization = sws.basicAuthHeader()
   } else if (auth !== null) {
     request.headers.Authorization = auth
   }

--- a/src/Service.js
+++ b/src/Service.js
@@ -69,6 +69,23 @@ export default class Service {
   }
 
   /**
+   * Returns an `Authorisation` header value comprised of
+   * either a bearer token or an application ID and secret
+   * depending which is available
+   *
+   * @protected
+   *
+   * @return {String} Auth header value
+   */
+  bearerTokenOrBasicAuthHeader () {
+    if(this._sws.accessToken) {
+      return bearerTokenAuthHeader()
+    } else if (this._sws.appId && this._sws.appSecret) {
+      return basicAuthHeader()
+    }
+  }
+
+  /**
    * Filters out empty and invalid values and returns a object
    * containing parameters for a request
    *

--- a/src/Service.js
+++ b/src/Service.js
@@ -374,14 +374,17 @@ function handleFetchError (request, err) {
  */
 function buildRequest (auth, endpoint, body, method, timeout, responseType, headers) {
   const request = {
-    timeout: timeout,
+    timeout,
     url: endpoint,
-    method: method,
-    responseType: responseType,
-    headers: headers
+    method,
+    responseType,
+    headers
   }
 
-  if (auth !== null) {
+  if (this._sws.isServerSide) {
+    request.headers['x-serato-cdn-auth'] = this.xSeratoCdnAuthHeader()
+    request.headers.Authorization = this.basicAuthHeader()
+  } else if (auth !== null) {
     request.headers.Authorization = auth
   }
 

--- a/src/Service.js
+++ b/src/Service.js
@@ -78,11 +78,13 @@ export default class Service {
    * @return {String} Auth header value
    */
   bearerTokenOrBasicAuthHeader () {
+    let header = ''
     if (this._sws.accessToken !== undefined) {
-      return bearerTokenAuthHeader()
+      header = this.bearerTokenAuthHeader()
     } else {
-      return basicAuthHeader()
+      header = this.basicAuthHeader()
     }
+    return header
   }
 
   /**

--- a/src/Sws.js
+++ b/src/Sws.js
@@ -74,7 +74,7 @@ export default class Sws {
    * @param {SwsConfiguration} config Configuration options
    * @return {void}
    */
-  constructor ({ appId, secret = '', timeout = 3000, serviceUri = {} }) {
+  constructor ({ appId, secret = '', timeout = 3000, serviceUri = {}, isServerSide }) {
     /** @private */
     this._appId = appId
     /** @private */
@@ -87,6 +87,8 @@ export default class Sws {
     this._refreshToken = ''
     /** @private */
     this._userId = 0
+    /** @private */
+    this._isServerSide = isServerSide
     /** @private */
     this._serviceUri = {
       id: serviceUri.id ? serviceUri.id : serviceUriDefault.id,
@@ -244,6 +246,23 @@ export default class Sws {
    */
   get userId () {
     return this._userId
+  }
+
+  /**
+   * Set the isServerSide property
+   * @param {Boolean} isServerSide
+   */
+  set isServerSide (isServerSide) {
+    this._isServerSide = isServerSide
+  }
+
+  /**
+   * Get the isServerSide property
+   *
+   * @return {Boolean}
+   */
+  get isServerSide () {
+    return this._isServerSide
   }
 
   /**

--- a/src/SwsClient.js
+++ b/src/SwsClient.js
@@ -36,8 +36,8 @@ export default class SwsClient extends Sws {
    * @param { import("./Sws").SwsConfiguration } config Configuration options
    * @return {void}
    */
-  constructor ({ appId, secret = '', timeout = 3000, serviceUri = {} }) {
-    super({ appId: appId, secret: secret, timeout: timeout, serviceUri: serviceUri })
+  constructor ({ appId, secret = '', timeout = 3000, serviceUri = {}, isServerSide }) {
+    super({ appId, secret, timeout, serviceUri, isServerSide })
 
     /** @private */
     this._accessTokenUpdatedHandler = () => {}

--- a/types/Sws.d.ts
+++ b/types/Sws.d.ts
@@ -1,5 +1,5 @@
 export default class Sws {
-    constructor({ appId, secret, timeout, serviceUri }: SwsConfiguration);
+    constructor({ appId, secret, timeout, serviceUri, isServerSide }: SwsConfiguration);
     private _appId;
     private _secret;
     private _timeout;
@@ -19,6 +19,7 @@ export default class Sws {
     get appId(): string;
     get appSecret(): string;
     get serviceUri(): ServiceUri;
+    get isServerSide(): boolean;
     set userId(arg: number);
     get userId(): number;
     set accessToken(arg: string);

--- a/types/Sws.d.ts
+++ b/types/Sws.d.ts
@@ -8,6 +8,7 @@ export default class Sws {
     private _userId;
     private _serviceUri;
     private _service;
+    private _isServerSide;
     setInvalidAccessTokenHandler(f: RequestErrorHandler): void;
     setInvalidRefreshTokenHandler(f: RequestErrorHandler): void;
     setPasswordReEntryRequiredHandler(f: RequestErrorHandler): void;
@@ -69,6 +70,7 @@ export type SwsConfiguration = {
     secret?: string;
     timeout?: number;
     serviceUri?: ServiceUri;
+    isServerSide?: boolean
 };
 export const serviceUriDefault: ServiceUri;
 import License from "./License";


### PR DESCRIPTION
All changes made **only** to the DA service get Assets endpoint
* When we are in build mode (no access token is available) add the CDN auth secret so that the DA service can be properly accessed
* If an access token is present, use bearer token. If no access token, return use basic auth header 