### PR TITLE
[WEB-10216] - CMS: Meganav notification content does not display

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serato/sws-sdk",
-  "version": "6.15.0",
+  "version": "6.16.0",
   "description": "Serato Web Services JS SDK",
   "main": "src/index.js",
   "types": "types/index.d.ts",

--- a/src/Notifications.js
+++ b/src/Notifications.js
@@ -357,7 +357,7 @@ export default class NotificationsService extends Service {
    * @param {GetMeNotificationsParams}  params
    * @return {Promise<NotificationList>}
    */
-  getMeNotifications ({ hostAppName, hostAppVersion, hostOsName, hostOsVersion, locale, deviceId, useAuth } = {}) {
+  getMeNotifications ({ hostAppName, hostAppVersion, hostOsName, hostOsVersion, locale, deviceId, useAuth = true } = {}) {
     return this.fetch(
       useAuth ? this.bearerTokenAuthHeader() : null,
       '/api/v2/me/notifications',

--- a/src/Notifications.js
+++ b/src/Notifications.js
@@ -149,6 +149,7 @@ import Service from './Service'
  * @property {String} [hostOsVersion = undefined] hostOsVersion     Host application OS version
  * @property {String} [locale = undefined] locale    Locale setting of the client application
  * @property {String} deviceId      ID of the device. Expected to be generated on a per device basis
+ * @property {Boolean} [useAuth = true]     Whether to use an auth header for this request
  *
  * @typedef {Object} CreateNotificationParams
  * @property {String} name           Name of the campaign message. Must be a non empty string
@@ -356,9 +357,9 @@ export default class NotificationsService extends Service {
    * @param {GetMeNotificationsParams}  params
    * @return {Promise<NotificationList>}
    */
-  getMeNotifications ({ hostAppName, hostAppVersion, hostOsName, hostOsVersion, locale, deviceId } = {}) {
+  getMeNotifications ({ hostAppName, hostAppVersion, hostOsName, hostOsVersion, locale, deviceId, useAuth } = {}) {
     return this.fetch(
-      this.bearerTokenAuthHeader(),
+      useAuth ? this.bearerTokenAuthHeader() : null,
       '/api/v2/me/notifications',
       this.toBody({
         host_app_name: hostAppName,

--- a/src/NotificationsV1.js
+++ b/src/NotificationsV1.js
@@ -96,7 +96,7 @@ export default class NotificationsV1Service extends Service {
    * @param  {GetNotificationsParams} [params = undefined] params
    * @return {Promise<NotificationList>}
    */
-  getNotifications ({ hostAppName, hostAppVersion, hostAppOs, locale, useAuth } = {}) {
+  getNotifications ({ hostAppName, hostAppVersion, hostAppOs, locale, useAuth = true } = {}) {
     return this.fetch(
       useAuth ? this.bearerTokenAuthHeader() : null,
       '/api/v1/notifications',

--- a/src/NotificationsV1.js
+++ b/src/NotificationsV1.js
@@ -71,6 +71,7 @@ import Service from './Service'
  * @property {String} [hostAppVersion = undefined] hostAppVersion
  * @property { import("./Notifications").OsName } [hostAppOs = undefined] hostAppOs
  * @property {String} [locale = undefined] locale
+ * @property {Boolean} [useAuth = true] useAuth
  */
 
 /**
@@ -95,9 +96,9 @@ export default class NotificationsV1Service extends Service {
    * @param  {GetNotificationsParams} [params = undefined] params
    * @return {Promise<NotificationList>}
    */
-  getNotifications ({ hostAppName, hostAppVersion, hostAppOs, locale } = {}) {
+  getNotifications ({ hostAppName, hostAppVersion, hostAppOs, locale, useAuth } = {}) {
     return this.fetch(
-      this.bearerTokenAuthHeader(),
+      useAuth ? this.bearerTokenAuthHeader() : null,
       '/api/v1/notifications',
       this.toBody({
         host_app_name: hostAppName,

--- a/types/Notifications.d.ts
+++ b/types/Notifications.d.ts
@@ -3,7 +3,7 @@ export default class NotificationsService extends Service {
     createCampaign({ name, anonymous, description, startsAt, endsAt }: Notifications.CreateCampaignParams): Promise<Notifications.Campaign>;
     updateCampaign({ campaignId, name, anonymous, description, status, startsAt, endsAt }: Notifications.UpdateCampaignParams): Promise<Notifications.Campaign>;
     getNotifications(): Promise<Notifications.NotificationList>;
-    getMeNotifications({ hostAppName, hostAppVersion, hostOsName, hostOsVersion, locale, deviceId }: Notifications.GetMeNotificationsParams): Promise<Notifications.NotificationList>;
+    getMeNotifications({ hostAppName, hostAppVersion, hostOsName, hostOsVersion, locale, deviceId, useAuth }: Notifications.GetMeNotificationsParams): Promise<Notifications.NotificationList>;
     createNotification({ name, campaignId, type, priority, templateName, templateOption, isPersistent, isTakeover, startsAt, endsAt }: Notifications.CreateNotificationParams): Promise<Notifications.Notification>;
     updateNotification({ notificationId, name, templateOption, type, priority, templateName, startsAt, endsAt, status, isPersistent, isTakeover, campaignId }: Notifications.UpdateNotificationParams): Promise<Notifications.Notification>;
     cloneNotification({ notificationId }: Notifications.CloneNotificationParams): Promise<Notifications.Notification>;
@@ -172,7 +172,8 @@ export namespace Notifications {
         hostOsName?: string,
         hostOsVersion?: string,
         locale?: string,
-        deviceId: string
+        deviceId: string,
+        useAuth?: boolean
     };
     export type UpdateNotificationParams = {
         notificationId: string;

--- a/types/NotificationsV1.d.ts
+++ b/types/NotificationsV1.d.ts
@@ -1,5 +1,5 @@
 export default class NotificationsV1Service extends Service {
-    getNotifications({ hostAppName, hostAppVersion, hostAppOs, locale }?: NotificationsV1.GetNotificationsParams): Promise<NotificationsV1.NotificationList>;
+    getNotifications({ hostAppName, hostAppVersion, hostAppOs, locale, useAuth }?: NotificationsV1.GetNotificationsParams): Promise<NotificationsV1.NotificationList>;
 }
 export namespace NotificationsV1 {
     export type MessageType = 'sale' | 'generic' | 'none';
@@ -69,6 +69,7 @@ export namespace NotificationsV1 {
         hostAppVersion?: string;
         hostAppOs?: import("./Notifications").Notifications.OsName;
         locale?: string;
+        useAuth?: boolean;
     };
 }
 import Service from "./Service";


### PR DESCRIPTION
Add optional `useAuth` param to notifications endpoints used to get meganav notifications. Default is true. When false, no auth header will be added to the request.

This solves the problem (for these endpoints) detailed in https://serato.atlassian.net/browse/WEB-10119
>We have some endpoints in our web services which are publicly accessible so no authorization header is required when accessing them. The JS SDK’s default behaviour always adds access token (when available) to the request header. This may cause some delay when the access token is not valid because our web services always validate the access token (even for public endpoints) and return an error code which then the SDK catch and refresh the token and retries. 

>We want to avoid this extra call for refreshing the token when the endpoint doesn’t need authorization header. This can be done by having an option in JS SDK to not include authorization header in the request when not needed.