### PR TITLE
[WEB-10903]  Expansions Window not showing correct ownership green ticks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serato/sws-sdk",
-  "version": "6.17.1",
+  "version": "6.17.2",
   "description": "Serato Web Services JS SDK",
   "main": "src/index.js",
   "types": "types/index.d.ts",

--- a/src/License.js
+++ b/src/License.js
@@ -122,7 +122,7 @@ export default class LicenseService extends Service {
    * @param {'true' | 'false'} [param.includeExpired = undefined] param.includeExpired returns expired subscription license
    * @return {Promise<LicenseList>}
    */
-  getLicenses ({ appName, appVersion, term } = {}) {
+  getLicenses ({ appName, appVersion, term, includeExpired } = {}) {
     return this.fetch(
       this.bearerTokenAuthHeader(),
       this.userId === 0 ? '/api/v1/me/licenses' : '/api/v1/users/' + this.userId + '/licenses',
@@ -174,7 +174,7 @@ export default class LicenseService extends Service {
    * @param {'true' | 'false'} [param.includeExpired = undefined] param.includeExpired returns expired subscription license
    * @return {Promise<ProductList>}
    */
-  getProducts ({ appName, appVersion, term, showLicenceActivations } = {}) {
+  getProducts ({ appName, appVersion, term, showLicenceActivations, includeExpired } = {}) {
     return this.fetch(
       this.bearerTokenAuthHeader(),
       this.userId === 0 ? '/api/v1/me/products' : '/api/v1/users/' + this.userId + '/products',

--- a/src/License.js
+++ b/src/License.js
@@ -119,13 +119,14 @@ export default class LicenseService extends Service {
    * @param {String} [param.appName = undefined] param.appName Only return licenses compatible with app
    * @param {String} [param.appVersion = undefined] param.appVersion Only return licenses compatible with app version `Major.minor.point`
    * @param {String} [param.term = undefined] param.term Only return licenses of specified term
+   * @param {'true' | 'false'} [param.includeExpired = undefined] param.includeExpired returns expired subscription license
    * @return {Promise<LicenseList>}
    */
   getLicenses ({ appName, appVersion, term } = {}) {
     return this.fetch(
       this.bearerTokenAuthHeader(),
       this.userId === 0 ? '/api/v1/me/licenses' : '/api/v1/users/' + this.userId + '/licenses',
-      this.toBody({ app_name: appName, app_version: appVersion, term })
+      this.toBody({ app_name: appName, app_version: appVersion, term, include_expired: includeExpired })
     )
   }
 
@@ -170,13 +171,14 @@ export default class LicenseService extends Service {
    * @param {String} [param.appVersion = undefined] param.appVersion Only return products compatible with app version `Major.minor.point`
    * @param {String} [param.term = undefined] param.term Only return product of specified term
    * @param {'true' | 'false'} [param.showLicenceActivations = undefined] param.showLicenceActivations Include activations for licenses
+   * @param {'true' | 'false'} [param.includeExpired = undefined] param.includeExpired returns expired subscription license
    * @return {Promise<ProductList>}
    */
   getProducts ({ appName, appVersion, term, showLicenceActivations } = {}) {
     return this.fetch(
       this.bearerTokenAuthHeader(),
       this.userId === 0 ? '/api/v1/me/products' : '/api/v1/users/' + this.userId + '/products',
-      this.toBody({ app_name: appName, app_version: appVersion, term: term, show_license_activations: showLicenceActivations })
+      this.toBody({ app_name: appName, app_version: appVersion, term: term, show_license_activations: showLicenceActivations, include_expired: includeExpired })
     )
   }
 


### PR DESCRIPTION
Some users' licenses do not have a deleted flag when the subscription expires, which causes an issue in MySerato2. For this reason, we decided to fetch only the licenses and products that are not expired, so I added a parameter called include_expired