### PR TITLE
[WEB-10431] SWS JS SDK - Export a custom fetch Error type

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,20 @@ resolve to a data object containing the response from the web service.
 > SDK v6 has some major breaking changes from v5.
 > Read the [changelist](./CHANGELIST-v6.md) for details.
 
+## Developer Notes
+
+All classes and data structures have corresponding Typescript definitions.
+
+Typescript definitions are primarily auto-generated from JSDoc annontations using the Typescript compiler, as described in the [Typescript documentation](https://www.typescriptlang.org/docs/handbook/declaration-files/dts-from-js.html). The [documentation](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) also describes which JSDoc annotations are supported.
+
+The initial `.d.ts` files produced by the Typescript compiler are output to the [types](./types) directory. The [tsbuilder](./tsbuilder.js) module then makes modifications to some auto-generated files.
+
+The entire build process can be initiated from the following npm script:
+
+```bash
+npm run build
+```
+
 ## Basic usage
 
 Basic usage consists of creating an `Sws` instance then calling a method on a service client:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serato/sws-sdk",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Serato Web Services JS SDK",
   "main": "src/index.js",
   "types": "types/index.d.ts",

--- a/src/Service.js
+++ b/src/Service.js
@@ -2,6 +2,7 @@
 
 import { Base64 } from 'js-base64'
 import axios from 'axios'
+import SwsError from './SwsError'
 
 /**
  * @typedef {'GET' | 'POST' | 'PUT' | 'DELETE' | 'OPTIONS'} HttpMethod
@@ -348,13 +349,7 @@ export default class Service {
 function handleFetchError (request, err) {
   if (err.response) {
     const errText = err.response.data.error ? err.response.data.error : err.response.data.message
-    const error = new Error(errText)
-    error.httpStatus = err.response.status
-    if (err.response.data.code) {
-      error.code = err.response.data.code
-    }
-    error.response = err.response
-    throw error
+    throw new SwsError(errText, err.response.status, err.response, err.response.data.code)
   } else {
     // If response is undefined, re-throw the exception
     throw err

--- a/src/SwsError.js
+++ b/src/SwsError.js
@@ -1,23 +1,26 @@
 'use strict'
 
 /**
+ *
+ * @typedef {Object<string, string>} Response
+ *
  * @classdesc Extends Error class to allow for additional properties.
  * @class
  * @extends Error
  */
 export default class SwsError extends Error {
-    /**
+  /**
    * Constructor
    *
-   * @param {number} httpStatus 
-   * @param {number|undefined} code 
-   * @param {import("axios").AxiosResponse} response
+   * @param {number} httpStatus
+   * @param {number|undefined} code
+   * @param {Response} response
    * @return {void}
    */
-    constructor(message, httpStatus, response, code = undefined) {
-        super(message)
-        this.httpStatus = httpStatus
-        this.response = response
-        this.code = code
-    }
+  constructor (message, httpStatus, response, code = undefined) {
+    super(message)
+    this.httpStatus = httpStatus
+    this.response = response
+    this.code = code
+  }
 }

--- a/src/SwsError.js
+++ b/src/SwsError.js
@@ -16,9 +16,9 @@ export default class SwsError extends Error {
    */
     constructor(message, httpStatus, response, code = undefined) {
         super(message)
+        // append additional properties to SwsError object for cleaner error handling in TS
         this.httpStatus = httpStatus
         this.response = response
         this.code = code
-        Object.setPrototypeOf(this, SwsError.prototype);
     }
 }

--- a/src/SwsError.js
+++ b/src/SwsError.js
@@ -1,0 +1,24 @@
+'use strict'
+
+/**
+ * @classdesc Extends Error class to allow for additional properties.
+ * @class
+ * @extends Error
+ */
+export default class SwsError extends Error {
+    /**
+   * Constructor
+   *
+   * @param {number} httpStatus 
+   * @param {number|undefined} code 
+   * @param {import("axios").AxiosResponse} response
+   * @return {void}
+   */
+    constructor(message, httpStatus, response, code = undefined) {
+        super(message)
+        this.httpStatus = httpStatus
+        this.response = response
+        this.code = code
+        Object.setPrototypeOf(this, SwsError.prototype);
+    }
+}

--- a/src/SwsError.js
+++ b/src/SwsError.js
@@ -16,7 +16,6 @@ export default class SwsError extends Error {
    */
     constructor(message, httpStatus, response, code = undefined) {
         super(message)
-        // append additional properties to SwsError object for cleaner error handling in TS
         this.httpStatus = httpStatus
         this.response = response
         this.code = code

--- a/src/index.js
+++ b/src/index.js
@@ -5,11 +5,10 @@ import 'fast-text-encoding'
 import Sws from './Sws'
 import SwsError from './SwsError'
 
-export { Sws }
+export { Sws, SwsError }
 export * from './Sws'
 export { default } from './SwsClient'
 export * from './SwsClient'
-export { SwsError }
 export * from './DigitalAssets'
 export * from './Ecom'
 export * from './Identity'

--- a/src/index.js
+++ b/src/index.js
@@ -3,12 +3,13 @@
 // Polyfills for IE11
 import 'fast-text-encoding'
 import Sws from './Sws'
+import SwsError from './SwsError'
 
 export { Sws }
 export * from './Sws'
 export { default } from './SwsClient'
 export * from './SwsClient'
-
+export { SwsError }
 export * from './DigitalAssets'
 export * from './Ecom'
 export * from './Identity'
@@ -18,3 +19,4 @@ export * from './NotificationsV1'
 export * from './Profile'
 export * from './Rewards'
 export * from './AiProxy'
+export * from './SwsError'

--- a/types/SwsError.d.ts
+++ b/types/SwsError.d.ts
@@ -1,0 +1,6 @@
+export default class SwsError extends Error {
+    constructor(message: any, httpStatus: number, response: import("axios").AxiosResponse, code?: number | undefined);
+    httpStatus: number;
+    response: import("axios").AxiosResponse<any, any>;
+    code: number;
+}

--- a/types/SwsError.d.ts
+++ b/types/SwsError.d.ts
@@ -1,6 +1,11 @@
 export default class SwsError extends Error {
-    constructor(message: any, httpStatus: number, response: import("axios").AxiosResponse, code?: number | undefined);
+    constructor(message: any, httpStatus: number, response: Response, code?: number | undefined);
     httpStatus: number;
-    response: import("axios").AxiosResponse<any, any>;
+    response: {
+        [x: string]: string;
+    };
     code: number;
 }
+export type Response = {
+    [x: string]: string;
+};

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,3 @@
-export { Sws };
 export * from "./Sws";
 export * from "./SwsClient";
 export * from "./DigitalAssets";
@@ -10,5 +9,8 @@ export * from "./NotificationsV1";
 export * from "./Profile";
 export * from "./Rewards";
 export * from "./AiProxy";
+export * from "./SwsError";
 export { default } from "./SwsClient";
 import Sws from "./Sws";
+import SwsError from "./SwsError";
+export { Sws, SwsError };


### PR DESCRIPTION
This branch is without express checkout merged into it.
Changes:
- create new SwsError class instead of needing to use the general Error class, to allow for custom properties now accessible in typescript files.
- Use SwsError class when throwing a fetch error.
- Update README to describe autogeneration of TS definition files.