### PR TITLE
[WEB-8993] Update out of date type definitions for payment method functions

### DIFF
--- a/src/Ecom.js
+++ b/src/Ecom.js
@@ -16,6 +16,7 @@ import Service from './Service'
  * @typedef {'en' | 'es' | 'de' | 'fr' | 'pt' | 'pl' | 'ko' | 'blank'} ProductVoucherOrderLanguage
  * @typedef {'pdf_and_csv' | 'csv'} ProductVoucherOrderFileType
  * @typedef {'promotion' | 'retention-offer' | 'upsell-offer' | 'retail'} ProductVoucherTypeType
+ * @typedef {'braintree'} PaymentProvider
  *
  * @typedef {Object} Discount
  * @property {String} name
@@ -135,7 +136,8 @@ import Service from './Service'
  * @property {Order[]} items
  *
  * @typedef {Object} PaymentMethod
- * @property {String} token The payment method unique ID
+ * @property {Number} id Unique ID for the payment method
+ * @property {String} token Payment provider specific token for the payment method
  * @property {Number} user_id
  * @property {String} [image_url = undefined] image_url A URL that points to a payment method image resource
  * @property {PaymentMethodType} type One of `CreditCard` or `PayPal`.
@@ -155,8 +157,9 @@ import Service from './Service'
  * @property {PaymentMethod[]} items
  *
  * @typedef {Object} PaymentGatewayToken
- * @property {String} token
+ * @property {String} client_token
  * @property {String} paypal_environment
+ * @property {PaymentProvider} provider
  *
  * @typedef {Object} VoucherType
  * @property {String} name

--- a/types/Ecom.d.ts
+++ b/types/Ecom.d.ts
@@ -96,6 +96,7 @@ export namespace Ecom {
     export type ProductVoucherOrderLanguage = 'en' | 'es' | 'de' | 'fr' | 'pt' | 'pl' | 'ko' | 'blank';
     export type ProductVoucherOrderFileType = 'pdf_and_csv' | 'csv';
     export type ProductVoucherTypeType = 'promotion' | 'retention-offer' | 'upsell-offer' | 'retail';
+    export type PaymentProvider = 'braintree';
     export type Discount = {
         name: string;
         amount: number;
@@ -214,6 +215,7 @@ export namespace Ecom {
         items: Order[];
     };
     export type PaymentMethod = {
+        id: number;
         token: string;
         user_id: number;
         image_url?: string;
@@ -234,8 +236,9 @@ export namespace Ecom {
         items: PaymentMethod[];
     };
     export type PaymentGatewayToken = {
-        token: string;
+        client_token: string;
         paypal_environment: string;
+        provider: PaymentProvider;
     };
     export type VoucherType = {
         name: string;


### PR DESCRIPTION
- First is getting the payment token - we (Raijin) have changed the schema in a previous story and forgot to update it
- Second is another schema change which was not updated 2 years also by Raijin, which is required for later work in Indra

Risk areas: Typescript compilation - neither function is being used by My Account where TypeScript is used so 0 risks there. These are about to be used by Indra but these changes will make them correct. No functional changes so there's no regression test required.